### PR TITLE
use timestamp instead of Instant in meta

### DIFF
--- a/redisless/Cargo.toml
+++ b/redisless/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8"
 prost = "0.7"
 get_if_addrs = "0.5"
 ipnet = "2.3"
+chrono = "0.4"
 
 [dev-dependencies]
 redis = "0.20"

--- a/redisless/src/storage/models/expiry.rs
+++ b/redisless/src/storage/models/expiry.rs
@@ -1,8 +1,8 @@
-use std::time::{Duration, Instant};
+use chrono::{offset::Utc, Duration};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Expiry {
-    pub timestamp: Instant,
+    pub timestamp: i64,
 }
 
 #[derive(Debug)]
@@ -10,16 +10,24 @@ pub struct TimeOverflow {}
 
 impl Expiry {
     pub fn new_from_millis(duration: u64) -> Result<Self, TimeOverflow> {
-        Instant::now()
-            .checked_add(Duration::from_millis(duration))
-            .map(|t| Self { timestamp: t })
+        Utc::now()
+            .checked_add_signed(Duration::milliseconds(duration as i64))
+            .map(|t| Self {
+                timestamp: t.timestamp_millis(),
+            })
             .ok_or(TimeOverflow {})
     }
 
     pub fn new_from_secs(duration: u64) -> Result<Self, TimeOverflow> {
-        Instant::now()
-            .checked_add(Duration::from_secs(duration))
-            .map(|t| Self { timestamp: t })
+        Utc::now()
+            .checked_add_signed(Duration::seconds(duration as i64))
+            .map(|t| Self {
+                timestamp: t.timestamp_millis(),
+            })
             .ok_or(TimeOverflow {})
+    }
+
+    pub fn duration_left_millis(&self) -> i64 {
+        self.timestamp - Utc::now().timestamp_millis()
     }
 }

--- a/redisless/src/storage/models/meta.rs
+++ b/redisless/src/storage/models/meta.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use super::{Expiry, RedisType};
 
 pub struct RedisMeta {
@@ -13,9 +11,10 @@ impl RedisMeta {
     }
 
     pub fn is_expired(&self) -> bool {
-        match &self.expiry {
-            Some(expiry) if expiry.timestamp <= Instant::now() => true,
-            _ => false,
+        if let Some(expiry) = &self.expiry {
+            expiry.duration_left_millis() <= 0
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
This should allow support more easily the implementations of meta
related command like TTL,PTTL,expireat,pexpireat...
see #22