### PR TITLE
Implement TTL and PTTL commands

### DIFF
--- a/redisless/src/command/mod.rs
+++ b/redisless/src/command/mod.rs
@@ -34,6 +34,8 @@ pub enum Command {
     Incr(Key),
     IncrBy(Key, i64),
     Exists(Key),
+    Ttl(Key),
+    Pttl(Key),
     Info,
     Ping,
     Quit,
@@ -205,6 +207,14 @@ impl Command {
                 b"EXISTS" | b"exists" | b"Exists" => {
                     let key = get_bytes_vec(v.get(1))?;
                     Ok(Exists(key))
+                }
+                b"TTL" | b"ttl" | b"Ttl" => {
+                    let key = get_bytes_vec(v.get(1))?;
+                    Ok(Ttl(key))
+                }
+                b"PTTL" | b"pttl" | b"Pttl" => {
+                    let key = get_bytes_vec(v.get(1))?;
+                    Ok(Pttl(key))
                 }
                 b"INFO" | b"info" | b"Info" => Ok(Info),
                 b"PING" | b"ping" | b"Ping" => Ok(Ping),

--- a/redisless/src/storage/in_memory.rs
+++ b/redisless/src/storage/in_memory.rs
@@ -49,6 +49,10 @@ impl Storage for InMemoryStorage {
         }
     }
 
+    fn meta(&self, key: &[u8]) -> Option<&RedisMeta> {
+        self.data_mapper.get(key)
+    }
+
     fn remove(&mut self, key: &[u8]) -> u32 {
         use RedisType::*;
         match self.data_mapper.remove_entry(key) {

--- a/redisless/src/storage/mod.rs
+++ b/redisless/src/storage/mod.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use models::expiry::Expiry;
 use models::RedisString;
 
+use self::models::RedisMeta;
+
 pub trait Storage {
     fn write(&mut self, key: &[u8], value: &[u8]);
     fn expire(&mut self, key: &[u8], expiry: Expiry) -> u32;
@@ -18,4 +20,5 @@ pub trait Storage {
     fn hwrite(&mut self, key: &[u8], value: HashMap<RedisString, RedisString>);
     fn hread(&mut self, key: &[u8], field_key: &[u8]) -> Option<&[u8]>;
     fn size(&self) -> u64;
+    fn meta(&self, key: &[u8]) -> Option<&RedisMeta>;
 }


### PR DESCRIPTION
Add a `meta` command to the `Storage` trait to get the current metadata
of a key. This should serve the `TYPE` command later (#28).
closes #22.