### PR TITLE
garbage collection

### DIFF
--- a/redisless/src/server/mod.rs
+++ b/redisless/src/server/mod.rs
@@ -195,6 +195,9 @@ fn start_server<T: Storage + Send + 'static>(
         }
     };
 
+    // start garbage collection
+    thread_pool.spawn(move || do_gc(&storage));
+
     // listen incoming requests
     for stream in listener.incoming() {
         match stream {
@@ -214,6 +217,10 @@ fn start_server<T: Storage + Send + 'static>(
             break;
         }
     }
+}
+
+fn do_gc<T: Storage /*+ Send + 'static*/>(storage: &Arc<Mutex<T>>) {
+    let storage = storage.clone();
 }
 
 fn handle_tcp_stream<T: Storage + Send + 'static>(

--- a/redisless/src/storage/mod.rs
+++ b/redisless/src/storage/mod.rs
@@ -15,12 +15,12 @@ pub trait Storage {
     fn write(&mut self, key: &[u8], value: &[u8]);
     fn extend(&mut self, key: &[u8], value: &[u8]) -> u64;
     fn expire(&mut self, key: &[u8], expiry: Expiry) -> u32;
-    fn read(&mut self, key: &[u8]) -> Option<&[u8]>;
+    fn read(&self, key: &[u8]) -> Option<&[u8]>;
     fn remove(&mut self, key: &[u8]) -> u32;
     fn contains(&mut self, key: &[u8]) -> bool;
     fn type_of(&mut self, key: &[u8]) -> &[u8];
     fn hwrite(&mut self, key: &[u8], value: HashMap<RedisString, RedisString>);
-    fn hread(&mut self, key: &[u8], field_key: &[u8]) -> Option<&[u8]>;
+    fn hread(&self, key: &[u8], field_key: &[u8]) -> Option<&[u8]>;
     fn size(&self) -> u64;
     fn meta(&self, key: &[u8]) -> Option<&RedisMeta>;
 }


### PR DESCRIPTION
still *WIP*

1. This PR strives to change the API of `Storage` to be more user-friendly. Specifically, `read`+`hread` to be read-only (taking `&self` instead of `&mut self`). This is to clear the ground to compose them with other commands. Specifically, `COPY` (#25) needs to call both `read` and `write` on the `Storage` and cannot have multiple mutable references.
2. there are 2 parts for this PR.

- first, read commands merely marks the values with expired TTL with a "tombstone" in an atomic, immutable way. this relaxes the `&mut self` requirement
- second, --- not implemented yet--- a GC worker is spawned. This thread should work the same as original Redis GC algorithm works [see here](https://redis.io/commands/expire#how-redis-expires-keys).