### PR TITLE
Add support for SADD, SCARD and SREM commands

### DIFF
--- a/redisless/src/server/tests/mod.rs
+++ b/redisless/src/server/tests/mod.rs
@@ -480,6 +480,27 @@ fn ltrim_lrem_rpoplpush() {
 
 #[test]
 #[serial]
+fn sadd_scard_srem() {
+    let (server, mut con) = get_redis_client_connection(3357);
+
+    let values = &["val1", "val2", "val3", "val1"][..];
+    let x: i64 = con.sadd("setkey", values).unwrap();
+    assert_eq!(x, 3);
+    let values2 = &["val3", "val4", "val5"][..];
+    let y: i64 = con.sadd("setkey", values2).unwrap();
+    assert_eq!(y, 2);
+    let a: i64 = con.scard("nokey").unwrap();
+    assert_eq!(a, 0);
+    let b: i64 = con.scard("setkey").unwrap();
+    assert_eq!(b, 5);
+    let values3 = &["val3", "val5", "val7"][..];
+    let i: i64 = con.srem("setkey", values3).unwrap();
+    assert_eq!(i, 2);
+    assert_eq!(server.stop(), Some(ServerState::Stopped));
+}
+
+#[test]
+#[serial]
 fn start_and_stop_server() {
     let server = Server::new(InMemoryStorage::new(), 3340);
     assert_eq!(server.start(), Some(ServerState::Started));

--- a/redisless/src/storage/mod.rs
+++ b/redisless/src/storage/mod.rs
@@ -4,7 +4,7 @@ mod tests;
 pub mod in_memory;
 pub mod models;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use models::expiry::Expiry;
 use models::RedisString;
@@ -21,6 +21,8 @@ pub trait Storage {
     fn type_of(&mut self, key: &[u8]) -> &[u8];
     fn lwrite(&mut self, key: &[u8], values: Vec<RedisString>);
     fn lread(&mut self, key: &[u8]) -> Option<&Vec<RedisString>>;
+    fn swrite(&mut self, key: &[u8], values: HashSet<RedisString>);
+    fn sread(&mut self, key: &[u8]) -> Option<&HashSet<RedisString>>;
     fn hwrite(&mut self, key: &[u8], value: HashMap<RedisString, RedisString>);
     fn hread(&mut self, key: &[u8], field_key: &[u8]) -> Option<&[u8]>;
     fn size(&self) -> u64;


### PR DESCRIPTION
1. Added support for SADD, SCARD and SREM commands
2. Added a set_store hashmap in InMemoryStorage to store sets
3. Added sread and swrite methods in storage trait to read and write sets
4. Added test for SADD, SCARD and SREM commands